### PR TITLE
Fix broken query

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -17,4 +17,5 @@
 * consider adding a struct when faced with long argument lists (for methods)
 * throw exception if cannot parse form in `make_list` (else case)
 * Because of the way we check joint constraints, `AB;CD;AC;BD;|ABCD|=10` does not only return results of total length 10 (so umm fix that)
+* Allow for Qat's complex constraint syntax as the entire query (e.g., `7-9:x*a`)
 * misc. TODOs in code

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -320,12 +320,21 @@ fn match_equation_internal(
                 let min_len = constraints.and_then(|constraints_inner|
                     constraints_inner.get(*var_name).map(|vc| vc.min_length)
                 ).flatten().unwrap_or(1usize);
-                let max_len = constraints.and_then(|constraints_inner|
+                let max_len_cfg = constraints.and_then(|constraints_inner|
                     constraints_inner.get(*var_name).map(|vc| vc.max_length)
                 ).flatten().unwrap_or(chars.len());
-                if min_len > max_len { return false; }
 
-                for l in min_len..=max_len {
+                let avail = chars.len();
+
+                // If the minimum exceeds what we have left, this path can't work
+                if min_len > avail {
+                    return false;
+                }
+
+                // Never try to slice past what's actually available
+                let capped_max = std::cmp::min(max_len_cfg, avail);
+
+                for l in min_len..=capped_max {
                     let candidate_chars = &chars[..l];
 
                     let bound_val = if matches!(first, FormPart::RevVar(_)) {


### PR DESCRIPTION
I was going down the list of Qat's examples and I found this simple-looking one that didn't work in Umiaq
```
|B|=6;AB;A~B
```
Turns out we were trying some stuff that couldn't work. This seems to fix it and all the other tests work fine too.