### PR TITLE
Fix for joint constraint edge case

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,6 @@
 * populate this file (`TODO.md`) with TODOs found in code comments
 * organize this file (at least sort... somehow)
 * implement better prefilters for Vars with forms (e.g., `A;A=(x*a)` currently has a prefilter of `.+`)
-* because of the way we check joint constraints, `AB;CD;AC;BD;|ABCD|=10` does not only return results of total length 10 (so umm fix that)
 * (?) add methods on `char` (and `String`?): `is_variable` and `is_literal` (just sugar for `is_ascii_uppercase`, `is_ascii_lowercase`)
 * return `None` vs `Err`
 * avoid duplicating work (e.g., `parse_form` call in `make_list`)

--- a/src/joint_constraints.rs
+++ b/src/joint_constraints.rs
@@ -85,6 +85,21 @@ impl JointConstraint {
         }
     }
 
+    /// Check this constraint against a *solution row* represented as a slice of Bindings
+    /// (one Bindings per form/pattern). Duplicates in `vars` count toward the sum.
+    /// Returns `false` if *any* referenced var is unbound across `parts`.
+    pub fn is_strictly_satisfied_by_parts(&self, parts: &[Bindings]) -> bool {
+        let mut total: usize = 0;
+        for &v in &self.vars {
+            let len = match resolve_var_len(parts, v) {
+                Some(len) => len,
+                None => return false, // strict: must be fully bound
+            };
+            total += len;
+        }
+        self.rel.allows(total.cmp(&self.target))
+    }
+
     // --- Test-only convenience for asserting behavior without needing real `Bindings`.
     //     This keeps tests independent of crate::bindings internals.
     #[cfg(test)]
@@ -95,6 +110,18 @@ impl JointConstraint {
         let total: usize = self.vars.iter().map(|v| map.get(v).unwrap().len()).sum();
         self.rel.allows(total.cmp(&self.target))
     }
+}
+
+/// Helper: find the current length of variable `v` across a slice of Bindings.
+/// Returns None if `v` is unbound in all Bindings in `parts`.
+#[inline]
+fn resolve_var_len(parts: &[Bindings], v: char) -> Option<usize> {
+    for b in parts {
+        if let Some(s) = b.get(v) {
+            return Some(s.len());
+        }
+    }
+    None
 }
 
 /// Parse a single joint-length expression that **starts at** a `'|'`.
@@ -153,6 +180,13 @@ impl JointConstraints {
     /// during search as a "non-pruning check".
     pub fn all_satisfied(&self, bindings: &Bindings) -> bool {
         self.as_vec.iter().all(|jc| jc.is_satisfied_by(bindings))
+    }
+
+    /// True iff **every** joint constraint is satisfied w.r.t. a slice of Bindings,
+    /// using mid-search semantics (unbound ⇒ skip/true).
+    /// Requires all referenced variables to be bound.
+    pub fn all_strictly_satisfied_for_parts(&self, parts: &[Bindings]) -> bool {
+        self.as_vec.iter().all(|jc| jc.is_strictly_satisfied_by_parts(parts))
     }
 
     // Test-only helper mirroring `all_satisfied` over a plain map.

--- a/src/joint_constraints.rs
+++ b/src/joint_constraints.rs
@@ -182,8 +182,7 @@ impl JointConstraints {
         self.as_vec.iter().all(|jc| jc.is_satisfied_by(bindings))
     }
 
-    /// True iff **every** joint constraint is satisfied w.r.t. a slice of Bindings,
-    /// using mid-search semantics (unbound ⇒ skip/true).
+    /// True iff **every** joint constraint is satisfied w.r.t. a slice of Bindings.
     /// Requires all referenced variables to be bound.
     pub fn all_strictly_satisfied_for_parts(&self, parts: &[Bindings]) -> bool {
         self.as_vec.iter().all(|jc| jc.is_strictly_satisfied_by_parts(parts))


### PR DESCRIPTION
I think this is an edge case but maybe not? Anyway, if there's a join constraint that takes into account more variables that are in any one form, account for that by applying a filter at the very end.