### PR TITLE
Joint to individual constraints

### DIFF
--- a/src/solver.rs
+++ b/src/solver.rs
@@ -1,5 +1,5 @@
 use crate::bindings::{Bindings, WORD_SENTINEL};
-use crate::joint_constraints::{parse_joint_constraints, JointConstraints};
+use crate::joint_constraints::{parse_joint_constraints, propagate_joint_to_var_bounds, JointConstraints};
 use crate::parser::{match_equation_all, parse_form, ParseError, ParsedForm};
 use crate::patterns::Patterns;
 use crate::scan_hints::{form_len_hints_pf, PatternLenHints};
@@ -241,10 +241,15 @@ pub fn solve_equation(input: &str, word_list: &[&str], num_results_requested: us
 
 
     // 4. Pull out the per-variable constraints collected from the equation.
-    let var_constraints = &patterns.var_constraints;
+    let mut var_constraints = patterns.var_constraints.clone();
 
     // 4a. Get the joint constraints
     let joint_constraints = parse_joint_constraints(input);
+
+    // 4a.1 Tighten per-variable constraints from joint constraints
+    if let Some(jcs) = joint_constraints.as_ref() {
+        propagate_joint_to_var_bounds(&mut var_constraints, jcs);
+    }
 
     // 4b. Build cheap, per-form length hints once (index-aligned with patterns/parsed_forms)
     let scan_hints: Vec<PatternLenHints> = parsed_forms
@@ -276,7 +281,7 @@ pub fn solve_equation(input: &str, word_list: &[&str], num_results_requested: us
             // Try matching the word against the parsed pattern.
             // `match_equation_all` returns a list of `Bindings` (variable→string maps)
             // that satisfy the pattern given the current constraints.
-            let matches = match_equation_all(word, &parsed_forms[i], Some(var_constraints), joint_constraints.as_ref());
+            let matches = match_equation_all(word, &parsed_forms[i], Some(&var_constraints), joint_constraints.as_ref());
 
             // 6. For each binding produced for this pattern/word:
             for binding in matches {

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -246,12 +246,12 @@ pub fn solve_equation(input: &str, word_list: &[&str], num_results_requested: us
     // 4a. Get the joint constraints
     let joint_constraints = parse_joint_constraints(input);
 
-    // 4a.1 Tighten per-variable constraints from joint constraints
+    // 4b. Tighten per-variable constraints from joint constraints
     if let Some(jcs) = joint_constraints.as_ref() {
         propagate_joint_to_var_bounds(&mut var_constraints, jcs);
     }
 
-    // 4b. Build cheap, per-form length hints once (index-aligned with patterns/parsed_forms)
+    // 4c. Build cheap, per-form length hints once (index-aligned with patterns/parsed_forms)
     let scan_hints: Vec<PatternLenHints> = parsed_forms
         .iter()
         .map(|pf| form_len_hints_pf(pf, &patterns.var_constraints, joint_constraints.as_ref()))


### PR DESCRIPTION
We create individual variable constraints from joint constraints, where applicable. This can help optimize some queries.

Example: `cargo run --release -- 'ABCDEFGHIJKLMN;|ABCDEFGHIJKLMN|=14;!=ABCDEFGHIJKLMN' -n 10`

Before: 
```
Loaded 113096 words in 0.050s; solved in 10.030s (2 tuples).
```

After:
```
Loaded 113096 words in 0.063s; solved in 0.016s (2 tuples).
```

I also took this opportunity to simplify the code somewhat and ditch a bunch of TODOs

I do think this will mess with some of the other PRs because the major change here is that bounds are just `usize` as opposed to `Option<usize>`