### PR TITLE
Better prefilter

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,5 @@
 * populate this file (`TODO.md`) with TODOs found in code comments
 * organize this file (at least sort... somehow)
-* implement better prefilters for `Var`s with forms (e.g., `A;A=(x*a)` currently has a prefilter of `.+`)
 * consider adding a struct when faced with long argument lists (for methods) (e.g., recursive_join)
 * return `None` vs `Err`
 * avoid duplicating work (e.g., `parse_form` call in `make_list`)

--- a/TODO.md
+++ b/TODO.md
@@ -13,3 +13,4 @@
 * use `Range`s for length ranges?
 * allow constraints like |A|<4, |B|>=5, etc.
 * throw exception if cannot parse form in `make_list` (else case)
+* Split out parser.rs into multiple smaller files

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -251,11 +251,11 @@ pub fn solve_equation(input: &str, word_list: &[&str], num_results_requested: us
 
     // 4a. Upgrade prefilters once per form (only if it helps)
     for pf in &mut parsed_forms {
-        if has_inlineable_var_form(&pf.parts, var_constraints) {
+        if has_inlineable_var_form(&pf.parts, &var_constraints) {
             // Build the anchored, constraint-aware pattern string
             let anchored = format!(
                 "^{}$",
-                form_to_regex_str_with_constraints(&pf.parts, Some(var_constraints))
+                form_to_regex_str_with_constraints(&pf.parts, Some(&var_constraints))
             );
 
             // Compile via the shared cache; fall back to the existing prefilter on error


### PR DESCRIPTION
Change the prefilter so that (for example) `A;A=(x*a)` gets a prefilter of `x*a` instead of `.+`. This results in a massive speed improvement on some queries, though to be fair, I haven't found one that was terribly slow to begin with.

Before: `Loaded 113096 words in 0.053s; solved in 0.145s (5 tuples).`
After: `Loaded 113096 words in 0.075s; solved in 0.041s (5 tuples).`

`parser.rs` is getting pretty long now -- I added a TODO to split it into multiple files. I don't think that would be that bad to do, but we have enough PRs as is for the moment.