### PR TITLE
Build documentation

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -51,6 +51,15 @@ jobs:
         run: |
           touch web/.nojekyll
 
+      # Build and stage Rust docs
+      - name: Build Rust docs
+        run: cargo doc --no-deps
+
+      - name: Copy docs into web/docs
+        run: |
+          mkdir -p web/docs
+          cp -r target/doc/* web/docs/
+
       - name: Upload site artifact
         # Package everything in web/ (index.html, pkg/, css, data, etc.)
         # as an artifact for the deploy job


### PR DESCRIPTION
I'm not sure if this is testable, but in theory the docs should live at https://crossword-nexus.github.io/umiaq/docs/umiaq afterward